### PR TITLE
Add Books page to navigation menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,4 +35,4 @@ plugins:
   - jekyll-gist
 
 # Pages
-pages_list:          {'Now':'/now','Quotes':'/quotes'}
+pages_list:          {'Now':'/now','Books':'/books','Quotes':'/quotes'}


### PR DESCRIPTION
## Summary
Added a new "Books" page to the site navigation menu in the Jekyll configuration.

## Changes
- Added `'Books':'/books'` entry to the `pages_list` configuration in `_config.yml`
- The Books page now appears in the navigation between the Now and Quotes pages

## Details
This change updates the site's navigation structure to include a new Books section. The page will be accessible at the `/books` route and will appear in the pages list menu alongside the existing Now and Quotes pages.

https://claude.ai/code/session_01QojLLYD7cvjFcU7MTVCfTa